### PR TITLE
Add Apps Script handlers for vending lineup

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -1,0 +1,98 @@
+/**
+ * Vending lineup web app entry point.
+ * @param {GoogleAppsScript.Events.DoGet} e
+ * @returns {GoogleAppsScript.HTML.HtmlOutput}
+ */
+function doGet(e) {
+  var params = (e && e.parameter) || {};
+  var maker = params.maker || '';
+  var folderId = params.folderId || '';
+
+  var template = HtmlService.createTemplateFromFile('VendingLineup');
+  template.maker = maker;
+  template.folderId = folderId;
+
+  return template
+    .evaluate()
+    .setTitle('商品ラインアップ')
+    .addMetaTag('viewport', 'width=device-width, initial-scale=1')
+    .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
+}
+
+/**
+ * Drive 上のフォルダ構造から商品ラインアップを返す。
+ * フォルダ直下に商品画像がある場合は "全商品" カテゴリとして扱い、
+ * サブフォルダがある場合はフォルダ名をカテゴリー名として扱う。
+ *
+ * @param {string} maker メーカー名
+ * @param {string} folderId 画像が格納された Drive フォルダ ID
+ * @returns {{manufacturer: string, categories: Array<{name: string, items: Array<{name: string, imageUrl: string, price: string}>}>}}
+ */
+function getVendingLineup(maker, folderId) {
+  var result = {
+    manufacturer: maker || 'ラインアップ',
+    categories: [],
+  };
+
+  if (!folderId) {
+    return result;
+  }
+
+  try {
+    var rootFolder = DriveApp.getFolderById(folderId);
+
+    var subfolders = rootFolder.getFolders();
+    while (subfolders.hasNext()) {
+      var categoryFolder = subfolders.next();
+      result.categories.push({
+        name: categoryFolder.getName(),
+        items: extractItems(categoryFolder),
+      });
+    }
+
+    if (!result.categories.length) {
+      result.categories.push({
+        name: '全商品',
+        items: extractItems(rootFolder),
+      });
+    }
+  } catch (err) {
+    throw new Error('商品情報の取得に失敗しました: ' + err.message);
+  }
+
+  return result;
+}
+
+/**
+ * 指定フォルダ配下のファイルから商品情報を抽出する。
+ * 価格はファイルの説明文に数字のみが記載されている場合に採用する。
+ *
+ * @param {GoogleAppsScript.Drive.Folder} folder
+ * @returns {Array<{name: string, imageUrl: string, price: string}>}
+ */
+function extractItems(folder) {
+  var items = [];
+  var files = folder.getFiles();
+
+  while (files.hasNext()) {
+    var file = files.next();
+    items.push({
+      name: file.getName(),
+      imageUrl: file.getUrl(),
+      price: parsePrice(file.getDescription()),
+    });
+  }
+
+  return items;
+}
+
+/**
+ * ファイル説明文から価格を抽出する。
+ * @param {string} description
+ * @returns {string}
+ */
+function parsePrice(description) {
+  if (!description) return '';
+  var match = String(description).match(/([0-9]{2,})/);
+  return match ? match[1] : '';
+}

--- a/VendingLineup
+++ b/VendingLineup
@@ -141,9 +141,12 @@
     <main id="lineupContainer"></main>
 
     <script>
+      const makerFromTemplate = <?!= JSON.stringify(maker || '') ?>;
+      const folderIdFromTemplate = <?!= JSON.stringify(folderId || '') ?>;
+
       const params = new URLSearchParams(window.location.search);
-      const maker = params.get('maker') || '';
-      const folderId = params.get('folderId') || '';
+      const maker = params.get('maker') || makerFromTemplate || '';
+      const folderId = params.get('folderId') || folderIdFromTemplate || '';
 
       document.addEventListener('DOMContentLoaded', function () {
         google.script.run


### PR DESCRIPTION
## Summary
- add doGet entrypoint to serve the lineup HTML with request parameters
- implement Drive-backed getVendingLineup helper to build categories and items
- expose template parameters in the HTML for maker and folder values

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b6d5c7b188328952d38e73b56c861)