### PR TITLE
Improve lineup layout and image handling

### DIFF
--- a/VendingLineup
+++ b/VendingLineup
@@ -5,12 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>商品ラインアップ</title>
     <style>
+      @import url('https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600&family=Noto+Sans+JP:wght@400;500;700&display=swap');
+
       :root {
-        --bg: #fefefe;
-        --card: #ffffff;
-        --accent: #6c5ce7;
-        --muted: #5f6368;
-        --border: #e6e8f0;
+        --accent: #ff7eb6;
+        --accent-2: #6c8cff;
+        --border: #e5e7f0;
+        --muted: #f7f8ff;
+        --text: #1f2430;
+        --shadow: 0 12px 28px rgba(61, 78, 255, 0.08);
       }
 
       * {
@@ -19,39 +22,92 @@
 
       body {
         margin: 0;
-        padding: 0;
-        font-family: 'Noto Sans JP', 'Inter', system-ui, -apple-system, BlinkMacSystemFont,
-          'Segoe UI', sans-serif;
-        background: linear-gradient(180deg, #f7f7ff 0%, #ffffff 60%);
-        color: #1f1f1f;
+        font-family: 'Noto Sans JP', 'Baloo 2', system-ui, -apple-system, sans-serif;
+        background: radial-gradient(circle at 10% 20%, #fff3fb 0, #f1f6ff 45%, #ffffff 90%);
+        color: var(--text);
       }
 
-      header {
-        padding: 20px 24px;
+      .page {
+        max-width: 1040px;
+        margin: 0 auto;
+        padding: 28px 16px 60px;
+      }
+
+      h1 {
+        font-size: 30px;
+        margin: 0 0 12px;
+        letter-spacing: 0.02em;
+      }
+
+      h2 {
+        margin: 4px 0 6px;
+      }
+
+      p.lead {
+        margin: 0 0 18px;
+        color: #3a3f52;
+        line-height: 1.7;
+      }
+
+      header.hero {
+        background: linear-gradient(120deg, rgba(255, 126, 182, 0.12), rgba(108, 140, 255, 0.12));
+        border: 1px solid var(--border);
+        border-radius: 20px;
+        padding: 22px 20px 20px;
+        box-shadow: var(--shadow);
+      }
+
+      .hero-badges {
         display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        margin-bottom: 8px;
+      }
+
+      .pill {
+        display: inline-flex;
         align-items: center;
-        justify-content: space-between;
-        gap: 12px;
-      }
-
-      .title {
-        display: flex;
-        flex-direction: column;
         gap: 6px;
+        background: #fff;
+        color: var(--text);
+        border: 1px solid var(--border);
+        padding: 6px 12px;
+        border-radius: 999px;
+        font-weight: 600;
       }
 
+      .pill.accent {
+        background: #1f1f1f;
+        color: #fff;
+        border-color: transparent;
+        box-shadow: 0 12px 24px rgba(0, 0, 0, 0.08);
+      }
+
+      .pill.alt {
+        background: #fff1f8;
+        color: #ff4f9d;
+        border-color: #ffd7eb;
+      }
+
+      section.block,
       .controls {
-        margin: 0 24px 8px;
-        padding: 16px;
         background: #fff;
         border: 1px solid var(--border);
-        border-radius: 14px;
-        box-shadow: 0 12px 30px rgba(31, 41, 55, 0.08);
+        border-radius: 16px;
+        padding: 18px 16px 20px;
+        margin-top: 16px;
+        box-shadow: var(--shadow);
       }
 
-      .control-form {
+      .controls form {
         display: grid;
         gap: 12px;
+      }
+
+      #lineupContainer {
+        margin-top: 16px;
+        display: grid;
+        gap: 16px;
       }
 
       .control-row {
@@ -69,15 +125,16 @@
         display: flex;
         flex-direction: column;
         gap: 8px;
-        font-weight: 600;
+        font-weight: 700;
+        color: #3a3f52;
       }
 
       select,
       textarea {
         width: 100%;
         border: 1px solid var(--border);
-        border-radius: 10px;
-        padding: 10px 12px;
+        border-radius: 12px;
+        padding: 12px;
         font-size: 14px;
         font-family: inherit;
         background: #f9fafb;
@@ -93,129 +150,162 @@
         justify-content: flex-end;
       }
 
-      h1 {
-        margin: 0;
-        font-size: 1.4rem;
-      }
-
-      .lead {
-        margin: 0;
-        color: var(--muted);
-      }
-
-      main {
-        max-width: 1100px;
-        margin: 0 auto;
-        padding: 0 20px 32px;
-      }
-
-      .category {
-        background: var(--card);
-        border: 1px solid var(--border);
-        border-radius: 14px;
-        padding: 16px;
-        margin-bottom: 18px;
-        box-shadow: 0 12px 30px rgba(0, 0, 0, 0.05);
-      }
-
-      .category-header {
-        display: flex;
+      button,
+      .button {
+        display: inline-flex;
         align-items: center;
+        justify-content: center;
+        gap: 6px;
+        padding: 12px 18px;
+        background: linear-gradient(120deg, var(--accent), var(--accent-2));
+        color: #fff;
+        border-radius: 14px;
+        font-weight: 800;
+        text-decoration: none;
+        border: none;
+        cursor: pointer;
+        box-shadow: 0 12px 24px rgba(255, 126, 182, 0.35);
+        transition: 0.18s ease;
+      }
+
+      button.secondary,
+      .button.secondary {
+        background: #1f1f1f;
+        box-shadow: 0 12px 24px rgba(0, 0, 0, 0.14);
+      }
+
+      button:hover,
+      .button:hover {
+        transform: translateY(-2px);
+      }
+
+      .section-header {
+        display: flex;
         justify-content: space-between;
-        gap: 8px;
-        margin-bottom: 12px;
-      }
-
-      .category-header h2 {
-        margin: 0;
-        font-size: 1.1rem;
-      }
-
-      .product-grid {
-        display: grid;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
+        align-items: flex-start;
         gap: 12px;
+        flex-wrap: wrap;
       }
 
-      @media (min-width: 768px) {
-        .product-grid {
-          grid-template-columns: repeat(3, minmax(0, 1fr));
-        }
+      .section-lead {
+        margin: 0;
+        color: #4a5066;
+        line-height: 1.6;
+        font-size: 14px;
       }
 
-      @media (min-width: 1024px) {
-        .product-grid {
-          grid-template-columns: repeat(4, minmax(0, 1fr));
-        }
+      .eyebrow {
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        font-weight: 700;
+        color: #8b92b2;
+        font-size: 12px;
+        margin: 0;
+      }
+
+      .card-grid {
+        position: relative;
+        display: grid;
+        gap: 12px;
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        align-items: stretch;
       }
 
       .manufacturer-grid {
         grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
       }
 
-      .product-card {
+      .card {
         border: 1px solid var(--border);
-        border-radius: 12px;
-        padding: 10px;
-        background: #fbfbff;
+        border-radius: 14px;
+        padding: 12px;
+        background: linear-gradient(180deg, #ffffff 0%, #f7f8ff 60%, #eef1ff 100%);
         display: flex;
         flex-direction: column;
-        gap: 8px;
-      }
-
-      .product-card img {
-        width: 100%;
-        height: 160px;
-        object-fit: cover;
-        border-radius: 10px;
-        background: #f5f6fb;
-        border: 1px solid #edf0f7;
-      }
-
-      .product-name {
-        margin: 0;
-        font-size: 1rem;
-      }
-
-      .product-price {
-        color: #2563eb;
-        font-weight: 800;
-      }
-
-      .manufacturer-card {
-        gap: 12px;
-      }
-
-      .manufacturer-card img {
-        height: 140px;
-      }
-
-      .button {
-        display: inline-block;
-        padding: 10px 14px;
-        background: var(--accent);
-        color: #fff;
-        border-radius: 10px;
-        font-weight: 700;
-        text-decoration: none;
+        gap: 10px;
+        position: relative;
+        box-shadow: 0 6px 18px rgba(22, 42, 97, 0.08);
+        align-items: center;
         text-align: center;
-        transition: transform 0.12s ease;
-        border: none;
-        cursor: pointer;
       }
 
-      .button:hover {
-        transform: translateY(-1px);
+      .card h3,
+      .card h4 {
+        margin: 0;
+        font-size: 15px;
       }
 
-      .button.secondary {
+      .badge {
+        position: absolute;
+        top: 10px;
+        right: 10px;
         background: #fff;
         color: var(--accent);
+        padding: 4px 8px;
+        border-radius: 10px;
         border: 1px solid var(--accent);
+        font-weight: 700;
+        font-size: 12px;
+      }
+
+      .media-frame {
+        width: 100%;
+        aspect-ratio: 3 / 4;
+        min-height: 160px;
+        border-radius: 12px;
+        background: linear-gradient(145deg, #fdf3ff, #f0f5ff);
+        border: 1px solid var(--border);
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        box-shadow: inset 0 4px 10px rgba(255, 255, 255, 0.8);
+      }
+
+      .media-frame img {
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+        display: block;
+        background: transparent;
+      }
+
+      .meta {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-size: 13px;
+        color: #555;
+        gap: 8px;
+        width: 100%;
+      }
+
+      .price {
+        font-size: 16px;
+        font-weight: 800;
+        color: #1e5ac9;
+      }
+
+      .maker {
+        font-weight: 700;
+        color: #34354a;
       }
 
       .empty {
-        color: var(--muted);
+        padding: 14px;
+        background: var(--muted);
+        border-radius: 10px;
+        text-align: center;
+        color: #3a3f52;
+      }
+
+      .note {
+        color: #4b4f65;
+        background: #fdf3ff;
+        border: 1px dashed #ffc0df;
+        padding: 10px 12px;
+        border-radius: 12px;
+        margin: 6px 0 10px;
       }
 
       .feature-table-wrapper {
@@ -249,25 +339,39 @@
         background: #f5f6fb;
         font-weight: 700;
       }
+
+      @media (max-width: 600px) {
+        h1 {
+          font-size: 24px;
+        }
+
+        .media-frame {
+          min-height: 180px;
+        }
+      }
     </style>
   </head>
-  <body>
-    <header>
-      <div class="title">
+  <body style="margin:auto 0;padding:auto 0;">
+    <div class="page">
+      <header class="hero">
+        <div class="hero-badges">
+          <span class="pill accent">Vending Lineup</span>
+          <span class="pill alt">画像プレビュー付き</span>
+        </div>
         <h1 id="pageTitle">商品ラインアップ</h1>
         <p id="pageLead" class="lead">メーカー別に商品と価格をまとめています。</p>
-      </div>
-    </header>
+      </header>
 
-    <section id="controls" class="controls"></section>
-    <main id="lineupContainer"></main>
+      <section id="controls" class="controls"></section>
+      <section id="lineupContainer"></section>
+    </div>
 
     <script>
       const makerFromTemplate = <?!= JSON.stringify(maker || '') ?>;
       const folderIdFromTemplate = <?!= JSON.stringify(folderId || '') ?>;
 
       const FALLBACK_IMAGE =
-        'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="480" height="320" viewBox="0 0 480 320"><rect fill="%23f5f6fb" width="480" height="320"/><text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="%2399a1b3" font-size="24" font-family="Inter, sans-serif">No Image</text></svg>';
+        'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="360" height="240" viewBox="0 0 360 240"><rect width="360" height="240" fill="%23f2f4f7"/><rect x="30" y="30" width="300" height="180" rx="12" fill="none" stroke="%23c3cad4" stroke-width="8"/><path d="M96 166l48-58 48 58 48-72 24 32" fill="none" stroke="%23c3cad4" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/><circle cx="138" cy="90" r="22" fill="%23d8dde5"/></svg>';
 
       const params = new URLSearchParams(window.location.search);
       const maker = params.get('maker') || makerFromTemplate || '';
@@ -276,14 +380,24 @@
       let currentQuestion = initialQuestion;
 
       function createImageElement(src, alt) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'media-frame';
+
         const img = document.createElement('img');
-        img.src = src || FALLBACK_IMAGE;
-        img.alt = alt || '商品画像';
         img.loading = 'lazy';
-        img.onerror = () => {
+        img.alt = alt || '商品画像';
+        img.referrerPolicy = 'no-referrer';
+
+        const applyFallback = () => {
+          img.onerror = null;
           img.src = FALLBACK_IMAGE;
         };
-        return img;
+
+        img.onerror = applyFallback;
+        img.src = src || FALLBACK_IMAGE;
+
+        wrapper.appendChild(img);
+        return wrapper;
       }
 
       function createFeaturesTable(items, categoryName) {
@@ -347,35 +461,49 @@
           container.innerHTML = '';
           categories.forEach((category) => {
             const section = document.createElement('section');
-            section.className = 'category';
+            section.className = 'block';
             section.innerHTML = `
-              <div class="category-header">
-                <h2>${category.name || 'カテゴリー'}</h2>
-                <span class="lead">${(category.items || []).length} 件</span>
+              <div class="section-header">
+                <div>
+                  <p class="eyebrow">ラインアップ</p>
+                  <h2>${category.name || 'カテゴリー'}</h2>
+                  <p class="section-lead">${(category.items || []).length} 件の商品を表示しています。</p>
+                </div>
               </div>
-              <div class="product-grid"></div>
+              <div class="card-grid product-grid"></div>
             `;
 
             const grid = section.querySelector('.product-grid');
             if (!category.items || !category.items.length) {
-              grid.innerHTML = '<p class="empty">商品が見つかりませんでした。</p>';
+              grid.innerHTML = '<div class="empty">商品が見つかりませんでした。</div>';
             } else {
               category.items.forEach((item) => {
                 const card = document.createElement('article');
-                card.className = 'product-card';
+                card.className = 'card product-card';
 
                 const img = createImageElement(item.imageUrl, item.name || '商品画像');
+                const badge = document.createElement('span');
+                badge.className = 'badge';
+                badge.textContent = category.name || 'カテゴリ';
+
+                const meta = document.createElement('div');
+                meta.className = 'meta';
+                const maker = document.createElement('span');
+                maker.className = 'maker';
+                maker.textContent = manufacturer || 'メーカー不明';
+                const price = document.createElement('span');
+                price.className = 'price';
+                price.textContent = item.price ? `¥${item.price}` : '価格未設定';
+                meta.appendChild(maker);
+                meta.appendChild(price);
+
                 const name = document.createElement('h3');
-                name.className = 'product-name';
                 name.textContent = item.name || '商品名';
 
-                const price = document.createElement('div');
-                price.className = 'product-price';
-                price.textContent = item.price ? `¥${item.price}` : '価格未設定';
-
                 card.appendChild(img);
+                card.appendChild(badge);
+                card.appendChild(meta);
                 card.appendChild(name);
-                card.appendChild(price);
                 grid.appendChild(card);
               });
 
@@ -393,27 +521,29 @@
           document.getElementById('pageLead').textContent = 'メーカーを選択して商品ラインアップをご覧ください。';
 
           const list = document.createElement('section');
-          list.className = 'category';
+          list.className = 'block';
           list.innerHTML = `
-            <div class="category-header">
-              <h2>メーカー</h2>
-              <span class="lead">${manufacturers.length} 件</span>
+            <div class="section-header">
+              <div>
+                <p class="eyebrow">メーカー一覧</p>
+                <h2>メーカー</h2>
+                <p class="section-lead">${manufacturers.length} 件のメーカーから選択できます。</p>
+              </div>
             </div>
-            <div class="product-grid manufacturer-grid"></div>
+            <div class="card-grid manufacturer-grid"></div>
           `;
 
           const grid = list.querySelector('.product-grid');
           manufacturers.forEach((makerInfo) => {
             const card = document.createElement('article');
-            card.className = 'product-card manufacturer-card';
+            card.className = 'card manufacturer-card';
 
             const img = createImageElement(makerInfo.imageUrl, makerInfo.name);
             const name = document.createElement('h3');
-            name.className = 'product-name';
             name.textContent = makerInfo.name;
 
             const anchor = document.createElement('a');
-            anchor.className = 'button';
+            anchor.className = 'button secondary';
             anchor.href = `?maker=${encodeURIComponent(makerInfo.name)}&folderId=${encodeURIComponent(makerInfo.folderId)}`;
             anchor.textContent = 'ラインアップを表示';
 
@@ -429,7 +559,7 @@
         }
 
         container.innerHTML =
-          '<p class="empty">現在表示できる商品情報がありません。商品の準備が整い次第、こちらに表示されます。</p>';
+          '<section class="block"><div class="empty">現在表示できる商品情報がありません。商品の準備が整い次第、こちらに表示されます。</div></section>';
       }
 
       function renderControls(manufacturers, selectedMaker) {
@@ -493,9 +623,9 @@
 
       function showError(err) {
         const container = document.getElementById('lineupContainer');
-        container.innerHTML = `<p class="empty">商品情報の取得に失敗しました。${
+        container.innerHTML = `<section class="block"><div class="empty">商品情報の取得に失敗しました。${
           err && err.message ? ` (詳細: ${err.message})` : ''
-        }</p>`;
+        }</div></section>`;
       }
     </script>
   </body>


### PR DESCRIPTION
## Summary
- refresh the vending lineup page with a hero header, badge styling, and updated grid cards
- add image frames with no-referrer loading and SVG fallbacks to display product and manufacturer images reliably
- style feature tables and empty/error states to match the new layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b7840f2608328a1fc39517dd18d0f)