### PR TITLE
Normalize google drive image URLs

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -144,7 +144,7 @@ function getFirstImageUrl(folder) {
 
 /**
  * 画像を埋め込み表示用の URL として返す。
- * Drive のファイルページ URL では直接表示できないため、uc?export=view を利用する。
+ * Drive のファイルページ URL では直接表示できないため、googleusercontent.com ドメインの URL を利用する。
  *
  * @param {GoogleAppsScript.Drive.File} file
  * @returns {string}
@@ -152,5 +152,5 @@ function getFirstImageUrl(folder) {
 function getImageUrl(file) {
   var id = file && file.getId && file.getId();
   if (!id) return '';
-  return 'https://drive.google.com/uc?export=view&id=' + id;
+  return 'https://lh3.googleusercontent.com/d/' + id;
 }

--- a/VendingLineup
+++ b/VendingLineup
@@ -379,6 +379,23 @@
       const initialQuestion = params.get('question') || '';
       let currentQuestion = initialQuestion;
 
+      function toEmbeddableUrl(src) {
+        if (!src) return '';
+
+        // If only an ID is passed, return the embeddable URL directly.
+        if (!/^https?:\/\//i.test(src)) {
+          return 'https://lh3.googleusercontent.com/d/' + src;
+        }
+
+        // Normalize common Drive share URLs to the embeddable googleusercontent format.
+        const idMatch = src.match(/(?:\/d\/|id=)([\w-]{10,})/);
+        if (idMatch && idMatch[1]) {
+          return 'https://lh3.googleusercontent.com/d/' + idMatch[1];
+        }
+
+        return src;
+      }
+
       function createImageElement(src, alt) {
         const wrapper = document.createElement('div');
         wrapper.className = 'media-frame';
@@ -394,7 +411,7 @@
         };
 
         img.onerror = applyFallback;
-        img.src = src || FALLBACK_IMAGE;
+        img.src = toEmbeddableUrl(src) || FALLBACK_IMAGE;
 
         wrapper.appendChild(img);
         return wrapper;


### PR DESCRIPTION
## Summary
- normalize frontend image rendering to convert Drive links and IDs into googleusercontent.com URLs
- ensure all displayed images use embeddable URLs or fall back safely

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b7aa84e988328adc2f4cec17237f2)