### PR TITLE
Unify manufacturer selection with simplified lineup table

### DIFF
--- a/VendingLineup
+++ b/VendingLineup
@@ -92,7 +92,7 @@
       section.block {
         background: #fff;
         border: 1px solid var(--border);
-        border-radius: 16px;
+        border-radius: 14px;
         padding: 18px 16px 20px;
         margin-top: 16px;
         box-shadow: var(--shadow);
@@ -139,11 +139,6 @@
         resize: vertical;
       }
 
-      .control-actions {
-        display: flex;
-        justify-content: flex-end;
-      }
-
       .question-two {
         display: flex;
         flex-direction: column;
@@ -165,8 +160,7 @@
         justify-content: flex-end;
       }
 
-      button,
-      .button {
+      button {
         display: inline-flex;
         align-items: center;
         justify-content: center;
@@ -176,21 +170,13 @@
         color: #fff;
         border-radius: 14px;
         font-weight: 800;
-        text-decoration: none;
         border: none;
         cursor: pointer;
         box-shadow: 0 12px 24px rgba(255, 126, 182, 0.35);
         transition: 0.18s ease;
       }
 
-      button.secondary,
-      .button.secondary {
-        background: #1f1f1f;
-        box-shadow: 0 12px 24px rgba(0, 0, 0, 0.14);
-      }
-
-      button:hover,
-      .button:hover {
+      button:hover {
         transform: translateY(-2px);
       }
 
@@ -218,162 +204,79 @@
         margin: 0;
       }
 
-      .card-grid {
-        position: relative;
-        display: grid;
-        gap: 12px;
-        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-        align-items: stretch;
-      }
-
-      .product-grid {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 12px;
-      }
-
-      .product-grid .product-card {
-        flex: 0 0 220px;
-      }
-
-      .manufacturer-grid {
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      }
-
-      .card {
-        border: 1px solid var(--border);
-        border-radius: 14px;
-        padding: 12px;
-        background: linear-gradient(180deg, #ffffff 0%, #f7f8ff 60%, #eef1ff 100%);
-        display: flex;
-        flex-direction: column;
-        gap: 10px;
-        position: relative;
-        box-shadow: 0 6px 18px rgba(22, 42, 97, 0.08);
-        align-items: center;
-        text-align: center;
-      }
-
-      .card.selectable {
-        cursor: pointer;
-        transition: 0.2s ease;
-      }
-
-      .card.selectable:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 10px 22px rgba(31, 90, 201, 0.18);
-      }
-
-      .card.selected {
-        border: 2px solid var(--accent-2);
-        box-shadow: 0 14px 28px rgba(108, 140, 255, 0.25);
-        background: linear-gradient(180deg, #f4f6ff 0%, #eaf0ff 60%, #eef3ff 100%);
-      }
-
-      .card.dimmed {
-        filter: grayscale(0.8);
-        opacity: 0.55;
-      }
-
-      .card h3,
-      .card h4 {
-        margin: 0;
-        font-size: 15px;
-      }
-
-      .badge {
-        position: absolute;
-        top: 10px;
-        right: 10px;
-        background: #fff;
-        color: var(--accent);
-        padding: 4px 8px;
-        border-radius: 10px;
-        border: 1px solid var(--accent);
-        font-weight: 700;
-        font-size: 12px;
+      .note {
+        color: #4b4f65;
+        background: #fdf3ff;
+        border: 1px dashed #ffc0df;
+        padding: 10px 12px;
+        border-radius: 12px;
+        margin: 6px 0 10px;
       }
 
       .media-frame {
         width: 100%;
-        aspect-ratio: 3 / 4;
-        min-height: 160px;
+        aspect-ratio: 4 / 3;
+        min-height: 120px;
         border-radius: 12px;
-        background: linear-gradient(145deg, #fdf3ff, #f0f5ff);
+        background: #f5f6fb;
         border: 1px solid var(--border);
         overflow: hidden;
         display: flex;
         align-items: center;
         justify-content: center;
-        box-shadow: inset 0 4px 10px rgba(255, 255, 255, 0.8);
       }
 
       .media-frame img {
         width: 100%;
         height: 100%;
-        object-fit: contain;
+        object-fit: cover;
         display: block;
         background: transparent;
       }
 
-      .feature-list {
-        list-style: none;
-        padding: 0;
-        margin: 6px 0 0;
-        width: 100%;
+      .image-grid {
         display: grid;
-        gap: 8px;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 12px;
+        margin: 12px 0 4px;
       }
 
-      .feature-item {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        justify-content: center;
-        font-weight: 700;
-        color: #1f2430;
-      }
-
-      .feature-badge {
-        min-width: 56px;
-        padding: 4px 10px;
-        border-radius: 999px;
-        font-size: 12px;
-        font-weight: 800;
-        border: 1px solid transparent;
-      }
-
-      .feature-badge.possible {
-        background: #ebf1ff;
-        color: #2f6bff;
-        border-color: #cdd9ff;
-      }
-
-      .feature-badge.unavailable {
-        background: #f3f4f7;
-        color: #8c94ab;
-        border-color: #dadee8;
-      }
-
-      .meta {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
+      .image-grid figcaption {
         font-size: 13px;
-        color: #555;
-        gap: 8px;
+        margin-top: 6px;
+        color: #3a3f52;
+        text-align: center;
+      }
+
+      .table-wrapper {
+        overflow-x: auto;
+        margin-top: 12px;
+      }
+
+      table.lineup-table {
         width: 100%;
+        border-collapse: collapse;
+        background: #fff;
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        overflow: hidden;
       }
 
-      .price {
-        font-size: 16px;
-        font-weight: 800;
-        color: #1e5ac9;
+      table.lineup-table th,
+      table.lineup-table td {
+        padding: 10px 12px;
+        border-bottom: 1px solid var(--border);
+        text-align: left;
+        font-size: 14px;
       }
 
-      .maker {
+      table.lineup-table th {
+        background: #f5f6fb;
         font-weight: 700;
-        color: #34354a;
+      }
+
+      table.lineup-table tbody tr:last-child td {
+        border-bottom: none;
       }
 
       .empty {
@@ -384,54 +287,9 @@
         color: #3a3f52;
       }
 
-      .note {
-        color: #4b4f65;
-        background: #fdf3ff;
-        border: 1px dashed #ffc0df;
-        padding: 10px 12px;
-        border-radius: 12px;
-        margin: 6px 0 10px;
-      }
-
-      .feature-table-wrapper {
-        margin-top: 12px;
-        overflow-x: auto;
-      }
-
-      .feature-table {
-        width: 100%;
-        border-collapse: collapse;
-        font-size: 14px;
-        background: #fff;
-        border: 1px solid var(--border);
-        border-radius: 12px;
-        overflow: hidden;
-      }
-
-      .feature-table th,
-      .feature-table td {
-        padding: 10px 12px;
-        border-bottom: 1px solid var(--border);
-        text-align: left;
-      }
-
-      .feature-table tbody tr:last-child th,
-      .feature-table tbody tr:last-child td {
-        border-bottom: none;
-      }
-
-      .feature-table th {
-        background: #f5f6fb;
-        font-weight: 700;
-      }
-
       @media (max-width: 600px) {
         h1 {
           font-size: 24px;
-        }
-
-        .media-frame {
-          min-height: 180px;
         }
       }
     </style>
@@ -455,8 +313,8 @@
       const folderIdFromTemplate = <?!= JSON.stringify(folderId || '') ?>;
 
       const SURVEY_TITLE = '新オフィスの自販機を皆さんの投票で決めます！';
-      const QUESTION1_DESCRIPTION = '４つのメーカーのうち、どれか一つ好きなメーカーを選んでください。';
-      const LINEUP_INSTRUCTION = '商品ラインアップをクリックすると商品が確認できます。';
+      const QUESTION1_DESCRIPTION = 'メーカー一覧と全商品を一体化しました。好きなメーカーを一つ選んでください。';
+      const LINEUP_INSTRUCTION = '４つの代表的な画像とシンプルな表でラインアップを確認できます。';
       const QUESTION2_DESCRIPTION =
         'オフィスの自販機に「これは絶対に欲しい！」という飲み物やカテゴリがあれば、自由にご記入ください。';
 
@@ -512,45 +370,6 @@
         return wrapper;
       }
 
-      function createFeaturesTable(items, categoryName) {
-        const wrapper = document.createElement('div');
-        wrapper.className = 'feature-table-wrapper';
-
-        const table = document.createElement('table');
-        table.className = 'feature-table';
-        table.innerHTML = `
-          <thead>
-            <tr>
-              <th>商品名</th>
-              <th>価格</th>
-              <th>カテゴリ</th>
-            </tr>
-          </thead>
-          <tbody></tbody>
-        `;
-
-        const tbody = table.querySelector('tbody');
-        items.forEach((item) => {
-          const tr = document.createElement('tr');
-          const nameCell = document.createElement('td');
-          nameCell.textContent = trimExtension(item.name) || '商品名未設定';
-
-          const priceCell = document.createElement('td');
-          priceCell.textContent = item.price ? `¥${item.price}` : '';
-
-          const categoryCell = document.createElement('td');
-          categoryCell.textContent = categoryName || 'カテゴリ未設定';
-
-          tr.appendChild(nameCell);
-          tr.appendChild(priceCell);
-          tr.appendChild(categoryCell);
-          tbody.appendChild(tr);
-        });
-
-        wrapper.appendChild(table);
-        return wrapper;
-      }
-
       function renderQuestionOneIntro(container) {
         const section = document.createElement('section');
         section.className = 'block';
@@ -558,7 +377,7 @@
           <div class="control-row">
             <div>
               <p class="eyebrow">質問１</p>
-              <h2>メーカーを選んでください</h2>
+              <h2>メーカー一覧と商品ラインアップ</h2>
               <p class="lead">${QUESTION1_DESCRIPTION}</p>
               <p class="note">${LINEUP_INSTRUCTION}</p>
             </div>
@@ -585,93 +404,6 @@
         `;
       }
 
-      function getMakerFeatures(name) {
-        if (!name) return [];
-        return MANUFACTURER_FEATURES[name] || [];
-      }
-
-      function renderFeatureList(name) {
-        const features = getMakerFeatures(name);
-        if (!features.length) return null;
-
-        const list = document.createElement('ul');
-        list.className = 'feature-list';
-
-        features.forEach((feature) => {
-          const item = document.createElement('li');
-          item.className = 'feature-item';
-
-          const badge = document.createElement('span');
-          badge.className = 'feature-badge ' + (feature.status === 'possible' ? 'possible' : 'unavailable');
-          badge.textContent = feature.status === 'possible' ? '可能' : '不可(販売会社決定)';
-
-          const text = document.createElement('span');
-          text.textContent = feature.label;
-
-          item.appendChild(badge);
-          item.appendChild(text);
-          list.appendChild(item);
-        });
-
-        return list;
-      }
-
-      function setupSelectableCards(grid) {
-        if (!grid) return;
-        const cards = Array.from(grid.querySelectorAll('.card.selectable'));
-        if (!cards.length) return;
-
-        const updateState = (selectedCard) => {
-          cards.forEach((card) => {
-            const isSelected = card === selectedCard;
-            card.classList.toggle('selected', isSelected);
-            card.classList.toggle('dimmed', !isSelected);
-          });
-        };
-
-        cards.forEach((card) => {
-          card.addEventListener('click', () => {
-            updateState(card);
-          });
-        });
-
-        updateState(cards[0]);
-      }
-
-      function renderManufacturerSelection(manufacturers, container) {
-        const list = document.createElement('section');
-        list.className = 'block';
-        list.innerHTML = `
-          <div class="section-header">
-            <div>
-              <h2>メーカーを選択</h2>
-              <p class="section-lead">画像をクリックして１社を選択してください。</p>
-            </div>
-          </div>
-          <div class="card-grid manufacturer-grid"></div>
-        `;
-
-        const grid = list.querySelector('.manufacturer-grid');
-        manufacturers.forEach((makerInfo) => {
-          const card = document.createElement('article');
-          card.className = 'card manufacturer-card selectable';
-
-          const img = createImageElement(makerInfo.imageUrl, makerInfo.name);
-          const name = document.createElement('h3');
-          name.textContent = makerInfo.name;
-
-          const features = renderFeatureList(makerInfo.name);
-
-          card.appendChild(img);
-          card.appendChild(name);
-          if (features) card.appendChild(features);
-          grid.appendChild(card);
-        });
-
-        container.appendChild(list);
-        setupSelectableCards(grid);
-      }
-
       function applySurveyHeaders(leadText) {
         document.getElementById('pageTitle').textContent = SURVEY_TITLE;
         document.getElementById('pageLead').textContent = leadText || QUESTION1_DESCRIPTION;
@@ -690,85 +422,100 @@
         const categories = (data && data.categories) || [];
         const manufacturers = (data && data.manufacturers) || [];
 
-        const shouldShowManufacturers = (!maker || maker === 'ラインアップ') && manufacturers.length;
+        const allItems = categories.flatMap((category) => {
+          if (!category.items || !category.items.length) return [];
+          return category.items.map((item) => ({ ...item, category: category.name || 'カテゴリ未設定' }));
+        });
 
         container.innerHTML = '';
         renderQuestionOneIntro(container);
         renderQuestionTwoSection();
         applySurveyHeaders(`${QUESTION1_DESCRIPTION} ${LINEUP_INSTRUCTION}`);
 
-        if (shouldShowManufacturers) {
-          renderManufacturerSelection(manufacturers, container);
-          return;
-        }
+        const section = document.createElement('section');
+        section.className = 'block';
 
-        if (categories.length) {
-          categories.forEach((category) => {
-            const section = document.createElement('section');
-            section.className = 'block';
-            section.innerHTML = `
-              <div class="section-header">
-                <div>
-                  <p class="eyebrow">自販機メーカー一覧</p>
-                  <h2>${category.name || 'カテゴリー'}</h2>
-                </div>
-              </div>
-              <div class="card-grid product-grid"></div>
-            `;
+        const sectionHeader = document.createElement('div');
+        sectionHeader.className = 'section-header';
+        sectionHeader.innerHTML = `
+          <div>
+            <p class="eyebrow">メーカーと商品</p>
+            <h2>好きなメーカーを選んでください</h2>
+            <p class="section-lead">一覧から一社を選び、下の表で商品ラインアップを確認できます。</p>
+          </div>
+        `;
 
-            const grid = section.querySelector('.product-grid');
-            if (!category.items || !category.items.length) {
-              grid.innerHTML = '<div class="empty">商品が見つかりませんでした。</div>';
-            } else {
-              category.items.forEach((item) => {
-                const card = document.createElement('article');
-                card.className = 'card product-card';
+        const controls = document.createElement('div');
+        controls.className = 'control-row';
+        controls.innerHTML = `
+          <label>
+            メーカー選択
+            <select>
+              ${(manufacturers.length
+                ? manufacturers
+                    .map((m) => `<option value="${m.name}">${m.name}</option>`)
+                    .join('')
+                : `<option>${manufacturer || 'メーカー未設定'}</option>`)}
+            </select>
+          </label>
+        `;
 
-                const itemDisplayName = trimExtension(item.name) || '商品名';
+        section.appendChild(sectionHeader);
+        section.appendChild(controls);
 
-                const img = createImageElement(item.imageUrl, itemDisplayName || '商品画像');
-                const badge = document.createElement('span');
-                badge.className = 'badge';
-                badge.textContent = category.name || 'カテゴリ';
-
-                const meta = document.createElement('div');
-                meta.className = 'meta';
-                const maker = document.createElement('span');
-                maker.className = 'maker';
-                maker.textContent = manufacturer || 'メーカー不明';
-                const price = document.createElement('span');
-                price.className = 'price';
-                price.textContent = item.price ? `¥${item.price}` : '';
-                meta.appendChild(maker);
-                if (item.price) meta.appendChild(price);
-
-                const name = document.createElement('h3');
-                name.textContent = itemDisplayName;
-
-                card.appendChild(img);
-                card.appendChild(badge);
-                card.appendChild(meta);
-                card.appendChild(name);
-                grid.appendChild(card);
-              });
-
-              const featureTable = createFeaturesTable(category.items, category.name);
-              section.appendChild(featureTable);
-            }
-
-            container.appendChild(section);
+        if (allItems.length) {
+          const imageGrid = document.createElement('div');
+          imageGrid.className = 'image-grid';
+          allItems.slice(0, 4).forEach((item) => {
+            const figure = document.createElement('figure');
+            figure.appendChild(createImageElement(item.imageUrl, trimExtension(item.name)));
+            const caption = document.createElement('figcaption');
+            caption.textContent = trimExtension(item.name) || '商品名未設定';
+            figure.appendChild(caption);
+            imageGrid.appendChild(figure);
           });
-          return;
+          section.appendChild(imageGrid);
+
+          const tableWrapper = document.createElement('div');
+          tableWrapper.className = 'table-wrapper';
+          const table = document.createElement('table');
+          table.className = 'lineup-table';
+          table.innerHTML = `
+            <thead>
+              <tr>
+                <th>商品名</th>
+                <th>カテゴリ</th>
+                <th>価格</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          `;
+
+          const tbody = table.querySelector('tbody');
+          allItems.forEach((item) => {
+            const tr = document.createElement('tr');
+            const nameCell = document.createElement('td');
+            nameCell.textContent = trimExtension(item.name) || '商品名未設定';
+
+            const categoryCell = document.createElement('td');
+            categoryCell.textContent = item.category || 'カテゴリ未設定';
+
+            const priceCell = document.createElement('td');
+            priceCell.textContent = item.price ? `¥${item.price}` : '';
+
+            tr.appendChild(nameCell);
+            tr.appendChild(categoryCell);
+            tr.appendChild(priceCell);
+            tbody.appendChild(tr);
+          });
+
+          tableWrapper.appendChild(table);
+          section.appendChild(tableWrapper);
+        } else {
+          section.innerHTML += '<div class="empty">商品が見つかりませんでした。</div>';
         }
 
-        if (manufacturers.length) {
-          applySurveyHeaders(`${QUESTION1_DESCRIPTION} ${LINEUP_INSTRUCTION}`);
-          renderManufacturerSelection(manufacturers, container);
-          return;
-        }
-
-        container.innerHTML =
-          '<section class="block"><div class="empty">現在表示できる商品情報がありません。商品の準備が整い次第、こちらに表示されます。</div></section>';
+        container.appendChild(section);
       }
 
       function showError(err) {


### PR DESCRIPTION
## Summary
- integrate manufacturer selection with product lineup and update copy to highlight a unified view
- present four representative images and a simple table for products instead of card grids
- streamline styling for the combined manufacturer and product section

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ba742f1b08328a50f29a4bdcb8d5b)