### PR TITLE
Add selectable vertical lineup images

### DIFF
--- a/VendingLineup
+++ b/VendingLineup
@@ -215,8 +215,8 @@
 
       .media-frame {
         width: 100%;
-        aspect-ratio: 4 / 3;
-        min-height: 120px;
+        aspect-ratio: 3 / 4;
+        min-height: 160px;
         border-radius: 12px;
         background: #fff;
         border: 1px solid var(--border);
@@ -247,6 +247,34 @@
         margin-top: 6px;
         color: #3a3f52;
         text-align: center;
+      }
+
+      .image-card {
+        margin: 0;
+        padding: 10px;
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        background: #fff;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        cursor: pointer;
+        transition: 0.18s ease;
+        box-shadow: 0 10px 20px rgba(61, 78, 255, 0.06);
+      }
+
+      .image-card:hover {
+        transform: translateY(-2px);
+      }
+
+      .image-card.selected {
+        border-color: var(--accent);
+        box-shadow: 0 14px 28px rgba(255, 126, 182, 0.28);
+      }
+
+      .image-card.dimmed {
+        opacity: 0.45;
+        filter: grayscale(0.7);
       }
 
       .maker-list {
@@ -335,7 +363,8 @@
 
       const SURVEY_TITLE = '新オフィスの自販機を皆さんの投票で決めます！';
       const QUESTION1_DESCRIPTION = 'メーカー一覧と全商品を一体化しました。好きなメーカーを一つ選んでください。';
-      const LINEUP_INSTRUCTION = '４つの代表的な画像とシンプルな表でラインアップを確認できます。';
+      const LINEUP_INSTRUCTION =
+        '４つの代表的な縦長画像をタップして気になるメーカーを選べます。シンプルな表でラインアップも確認してください。';
       const QUESTION2_DESCRIPTION =
         'オフィスの自販機に「これは絶対に欲しい！」という飲み物やカテゴリがあれば、自由にご記入ください。';
 
@@ -389,6 +418,32 @@
 
         wrapper.appendChild(img);
         return wrapper;
+      }
+
+      function enableImageSelection(imageGrid) {
+        const cards = Array.from(imageGrid.querySelectorAll('.image-card'));
+        if (!cards.length) return;
+
+        const applySelection = (selectedCard) => {
+          cards.forEach((card) => {
+            const isSelected = card === selectedCard;
+            card.classList.toggle('selected', isSelected);
+            card.classList.toggle('dimmed', !!selectedCard && !isSelected);
+            card.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
+          });
+        };
+
+        cards.forEach((card) => {
+          const selectCard = () => applySelection(card);
+
+          card.addEventListener('click', selectCard);
+          card.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              selectCard();
+            }
+          });
+        });
       }
 
       function renderQuestionTwoSection() {
@@ -464,12 +519,17 @@
           imageGrid.className = 'image-grid';
           allItems.slice(0, 4).forEach((item) => {
             const figure = document.createElement('figure');
+            figure.className = 'image-card';
+            figure.tabIndex = 0;
+            figure.setAttribute('role', 'button');
+            figure.setAttribute('aria-pressed', 'false');
             figure.appendChild(createImageElement(item.imageUrl, trimExtension(item.name)));
             const caption = document.createElement('figcaption');
             caption.textContent = trimExtension(item.name) || '商品名未設定';
             figure.appendChild(caption);
             imageGrid.appendChild(figure);
           });
+          enableImageSelection(imageGrid);
           section.appendChild(imageGrid);
 
           const tableWrapper = document.createElement('div');


### PR DESCRIPTION
## Summary
- change lineup image frames to vertical aspect ratio and add card styling
- allow users to select an image card and visually highlight their choice while dimming others
- update lineup instructions to mention tapping images

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694baaf95d808328b8469e88beb22882)