### PR TITLE
Keep lineup images in a single horizontal row

### DIFF
--- a/VendingLineup
+++ b/VendingLineup
@@ -237,9 +237,12 @@
 
       .image-grid {
         display: grid;
-        grid-template-columns: repeat(4, minmax(0, 1fr));
+        grid-auto-flow: column;
+        grid-auto-columns: minmax(220px, 1fr);
         gap: 12px;
         margin: 12px 0 4px;
+        overflow-x: auto;
+        padding-bottom: 6px;
       }
 
       .maker-ribbon {
@@ -295,6 +298,7 @@
         display: flex;
         flex-direction: column;
         gap: 8px;
+        min-width: 220px;
         cursor: pointer;
         transition: 0.18s ease;
         box-shadow: 0 10px 20px rgba(61, 78, 255, 0.06);


### PR DESCRIPTION
## Summary
- adjust the lineup image grid to flow horizontally with scroll support so images stay on one row
- enforce a minimum width for image cards to prevent unintended wrapping

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bb5607bdc8328b72800451fa17aef)