### PR TITLE
Collect survey responses into spreadsheet

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -1,6 +1,12 @@
 /** デフォルトで参照するメーカー一覧フォルダ ID */
 var DEFAULT_MANUFACTURERS_FOLDER_ID = '1AJd4BTFTVrLNep44PDz1AuwSF_5TFxdx';
 
+/** 集計結果を書き込むスプレッドシート ID */
+var SURVEY_SPREADSHEET_ID = '1xkg8vNscpcWTA6GA0VPxGTJCAH6LyvsYhq7VhOlDcXg';
+
+/** 集計結果を書き込むシート名 */
+var SURVEY_SHEET_NAME = '集計';
+
 /**
  * Vending lineup web app entry point.
  * @param {GoogleAppsScript.Events.DoGet} e
@@ -158,4 +164,24 @@ function getImageUrl(file) {
   var id = file && file.getId && file.getId();
   if (!id) return '';
   return 'https://lh3.googleusercontent.com/d/' + id;
+}
+
+/**
+ * アンケートの回答をスプレッドシートに保存する。
+ * @param {string} email メールアドレス
+ * @param {string} question1Answer 質問1の回答
+ * @param {string} question2Answer 質問2の回答
+ */
+function submitSurveyResponse(email, question1Answer, question2Answer) {
+  if (!SURVEY_SPREADSHEET_ID) {
+    throw new Error('集計先のスプレッドシート ID が設定されていません。');
+  }
+
+  var spreadsheet = SpreadsheetApp.openById(SURVEY_SPREADSHEET_ID);
+  var sheet = spreadsheet.getSheetByName(SURVEY_SHEET_NAME);
+  if (!sheet) {
+    throw new Error('集計シートが見つかりません。');
+  }
+
+  sheet.appendRow([new Date(), email || '', question1Answer || '', question2Answer || '']);
 }

--- a/VendingLineup
+++ b/VendingLineup
@@ -124,7 +124,8 @@
       }
 
       select,
-      textarea {
+      textarea,
+      input[type='email'] {
         width: 100%;
         border: 1px solid var(--border);
         border-radius: 12px;
@@ -137,6 +138,16 @@
       textarea {
         min-height: 96px;
         resize: vertical;
+      }
+
+      .status-message {
+        margin: 0;
+        font-size: 13px;
+        color: #2f3345;
+      }
+
+      .status-message.error {
+        color: #d92b4c;
       }
 
       .question-two {
@@ -424,6 +435,8 @@
       const maker = params.get('maker') || makerFromTemplate || '';
       const folderId = params.get('folderId') || folderIdFromTemplate || '';
 
+      let selectedMakerName = maker || '';
+
       function buildCatalogUrl(makerName, folderId) {
         if (!folderId) return '';
 
@@ -484,16 +497,19 @@
         return wrapper;
       }
 
-      function enableImageSelection(imageGrid) {
+      function enableImageSelection(imageGrid, onSelect) {
         const cards = Array.from(imageGrid.querySelectorAll('.image-card'));
         if (!cards.length) return;
 
-        const applySelection = (selectedCard) => {
+        const applySelection = (selectedCard, shouldNotify = true) => {
           cards.forEach((card) => {
             const isSelected = card === selectedCard;
             card.classList.toggle('selected', isSelected);
             card.classList.toggle('dimmed', !!selectedCard && !isSelected);
             card.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
+            if (isSelected && shouldNotify && typeof onSelect === 'function') {
+              onSelect(card.dataset.makerName || '');
+            }
           });
         };
 
@@ -508,6 +524,12 @@
             }
           });
         });
+
+        const initialCard =
+          cards.find((card) => (card.dataset.makerName || '') === maker) || cards[0];
+        if (initialCard) {
+          applySelection(initialCard, true);
+        }
       }
 
       function renderQuestionTwoSection() {
@@ -520,12 +542,59 @@
             <p class="lead">${QUESTION2_DESCRIPTION}</p>
           </div>
           <div class="question-two-body">
+            <label>
+              メールアドレス
+              <input type="email" placeholder="survey@example.com" />
+            </label>
             <textarea placeholder="欲しい商品やカテゴリを自由にご記入ください"></textarea>
+            <p class="status-message" aria-live="polite"></p>
             <div class="question-two-actions">
               <button type="button">送信</button>
             </div>
           </div>
         `;
+
+        const textarea = questionTwo.querySelector('textarea');
+        const emailInput = questionTwo.querySelector('input[type="email"]');
+        const submitButton = questionTwo.querySelector('button');
+        const statusElement = questionTwo.querySelector('.status-message');
+
+        const setStatus = (message, isError) => {
+          statusElement.textContent = message || '';
+          statusElement.classList.toggle('error', !!isError);
+        };
+
+        submitButton.addEventListener('click', () => {
+          const email = (emailInput.value || '').trim();
+          const question2Answer = (textarea.value || '').trim();
+          const question1Answer = selectedMakerName || '';
+
+          if (!email) {
+            setStatus('メールアドレスを入力してください。', true);
+            emailInput.focus();
+            return;
+          }
+
+          if (!question1Answer) {
+            setStatus('質問１の回答を選択してください。', true);
+            return;
+          }
+
+          submitButton.disabled = true;
+          setStatus('送信中です...', false);
+
+          google.script.run
+            .withSuccessHandler(() => {
+              setStatus('送信しました。ご協力ありがとうございます！');
+              textarea.value = '';
+              submitButton.disabled = false;
+            })
+            .withFailureHandler((err) => {
+              setStatus(`送信に失敗しました。${err && err.message ? err.message : ''}`, true);
+              submitButton.disabled = false;
+            })
+            .submitSurveyResponse(email, question1Answer, question2Answer);
+        });
       }
 
       function applySurveyHeaders(leadText) {
@@ -644,13 +713,16 @@
           figure.tabIndex = 0;
           figure.setAttribute('role', 'button');
           figure.setAttribute('aria-pressed', 'false');
+          figure.dataset.makerName = displayName;
           figure.appendChild(createImageElement(makerEntry.imageUrl, displayName));
           const caption = document.createElement('figcaption');
           caption.textContent = displayName;
           figure.appendChild(caption);
           imageGrid.appendChild(figure);
         });
-        enableImageSelection(imageGrid);
+        enableImageSelection(imageGrid, (name) => {
+          selectedMakerName = name;
+        });
         section.appendChild(imageGrid);
 
         const tableWrapper = document.createElement('div');


### PR DESCRIPTION
## Summary
- add Apps Script endpoint to append survey submissions to the provided 集計 sheet
- capture email, question1 selection, and question2 free text from the UI before sending
- add selection tracking, email field, and status messaging for the submit action

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c9a8b212c8328b6f44efba43513d6)