### PR TITLE
Fix survey submission without email input

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -168,11 +168,10 @@ function getImageUrl(file) {
 
 /**
  * アンケートの回答をスプレッドシートに保存する。
- * @param {string} email メールアドレス
  * @param {string} question1Answer 質問1の回答
  * @param {string} question2Answer 質問2の回答
  */
-function submitSurveyResponse(email, question1Answer, question2Answer) {
+function submitSurveyResponse(question1Answer, question2Answer) {
   if (!SURVEY_SPREADSHEET_ID) {
     throw new Error('集計先のスプレッドシート ID が設定されていません。');
   }
@@ -182,6 +181,8 @@ function submitSurveyResponse(email, question1Answer, question2Answer) {
   if (!sheet) {
     throw new Error('集計シートが見つかりません。');
   }
+
+  var email = Session.getActiveUser().getEmail();
 
   sheet.appendRow([new Date(), email || '', question1Answer || '', question2Answer || '']);
 }

--- a/Code.gs
+++ b/Code.gs
@@ -182,7 +182,28 @@ function submitSurveyResponse(question1Answer, question2Answer) {
     throw new Error('集計シートが見つかりません。');
   }
 
-  var email = Session.getActiveUser().getEmail();
+  var email = getUserEmail();
 
   sheet.appendRow([new Date(), email || '', question1Answer || '', question2Answer || '']);
+}
+
+/**
+ * 現在ログインしているユーザーのメールアドレスを内部的に取得する。
+ * Apps Script の実行権限に応じて ActiveUser または EffectiveUser を参照する。
+ * @returns {string}
+ */
+function getUserEmail() {
+  var active = Session.getActiveUser();
+  if (active) {
+    var email = active.getEmail();
+    if (email) return email;
+  }
+
+  var effective = Session.getEffectiveUser();
+  if (effective) {
+    var effectiveEmail = effective.getEmail();
+    if (effectiveEmail) return effectiveEmail;
+  }
+
+  return '';
 }

--- a/VendingLineup
+++ b/VendingLineup
@@ -542,10 +542,6 @@
             <p class="lead">${QUESTION2_DESCRIPTION}</p>
           </div>
           <div class="question-two-body">
-            <label>
-              メールアドレス
-              <input type="email" placeholder="survey@example.com" />
-            </label>
             <textarea placeholder="欲しい商品やカテゴリを自由にご記入ください"></textarea>
             <p class="status-message" aria-live="polite"></p>
             <div class="question-two-actions">
@@ -555,7 +551,6 @@
         `;
 
         const textarea = questionTwo.querySelector('textarea');
-        const emailInput = questionTwo.querySelector('input[type="email"]');
         const submitButton = questionTwo.querySelector('button');
         const statusElement = questionTwo.querySelector('.status-message');
 
@@ -565,15 +560,8 @@
         };
 
         submitButton.addEventListener('click', () => {
-          const email = (emailInput.value || '').trim();
           const question2Answer = (textarea.value || '').trim();
           const question1Answer = selectedMakerName || '';
-
-          if (!email) {
-            setStatus('メールアドレスを入力してください。', true);
-            emailInput.focus();
-            return;
-          }
 
           if (!question1Answer) {
             setStatus('質問１の回答を選択してください。', true);
@@ -593,7 +581,7 @@
               setStatus(`送信に失敗しました。${err && err.message ? err.message : ''}`, true);
               submitButton.disabled = false;
             })
-            .submitSurveyResponse(email, question1Answer, question2Answer);
+            .submitSurveyResponse(question1Answer, question2Answer);
         });
       }
 


### PR DESCRIPTION
## Summary
- remove the email input from the question 2 form and keep submission focused on selection and comments
- update the client submission handler to only validate the maker choice and send responses without a user-entered email
- collect the active user email server-side when writing survey responses to the spreadsheet

## Testing
- Not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c9d2a704c8328bc4add52fc0cae56)