### PR TITLE
Ensure Drive images are shared for public viewing

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -163,6 +163,21 @@ function getFirstImageInfo(folder) {
 function getImageUrl(file) {
   var id = file && file.getId && file.getId();
   if (!id) return '';
+
+  try {
+    var access = file.getSharingAccess();
+    var permission = file.getSharingPermission();
+    var isPublic =
+      access === DriveApp.Access.ANYONE_WITH_LINK &&
+      permission === DriveApp.Permission.VIEW;
+
+    if (!isPublic) {
+      file.setSharing(DriveApp.Access.ANYONE_WITH_LINK, DriveApp.Permission.VIEW);
+    }
+  } catch (err) {
+    Logger.log('画像の公開設定変更に失敗しました: ' + err.message);
+  }
+
   return 'https://lh3.googleusercontent.com/d/' + id;
 }
 


### PR DESCRIPTION
## Summary
- ensure Drive image URLs are publicly accessible by updating sharing to "anyone with link" when generating image URLs
- add logging when sharing updates fail to aid troubleshooting

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ca3d006808328a46f1f6eabfd8228)