### PR TITLE
Update catalog links to public Drive folders

### DIFF
--- a/VendingLineup
+++ b/VendingLineup
@@ -663,7 +663,7 @@
             },
             note: isAsahi ? '※設置できない可能性あり' : '',
             catalogLink: catalogUrl
-              ? { href: catalogUrl, text: 'カタログを見る' }
+              ? { href: catalogUrl, text: 'カタログ' }
               : '準備中',
           };
         });


### PR DESCRIPTION
## Summary
- map manufacturer catalogs to shared Google Drive folder links so users can navigate to full contents
- ensure catalog folders are shared for viewing and handled alongside existing file links
- display catalog link text as "カタログ" in the lineup table

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cbde7bc588328847f6b1c3cd4c657)