### PR TITLE
Handle missing effective user permission

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -282,10 +282,14 @@ function getUserEmail() {
     if (email) return email;
   }
 
-  var effective = Session.getEffectiveUser();
-  if (effective) {
-    var effectiveEmail = effective.getEmail();
-    if (effectiveEmail) return effectiveEmail;
+  try {
+    var effective = Session.getEffectiveUser();
+    if (effective) {
+      var effectiveEmail = effective.getEmail();
+      if (effectiveEmail) return effectiveEmail;
+    }
+  } catch (err) {
+    Logger.log('EffectiveUser 取得時に権限エラーが発生しました: ' + err.message);
   }
 
   return '';


### PR DESCRIPTION
## Summary
- prevent Session.getEffectiveUser from throwing when userinfo.email scope is unavailable
- log permission issues and gracefully fall back to empty email values

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cc1292ff483289a3bb2456762c86b)