### PR TITLE
Prioritize manufacturer list sourced from Drive folder

### DIFF
--- a/VendingLineup
+++ b/VendingLineup
@@ -672,10 +672,10 @@
         };
 
         const prioritizedManufacturers =
-          folderBasedManufacturers.length > 0
-            ? folderBasedManufacturers
-            : normalizedManufacturers.length > 0
+          normalizedManufacturers.length > 0
             ? normalizedManufacturers
+            : folderBasedManufacturers.length > 0
+            ? folderBasedManufacturers
             : [fallbackMaker];
 
         const paddedManufacturers = prioritizedManufacturers


### PR DESCRIPTION
## Summary
- prioritize manufacturer lineup data returned from the default Drive folder
- fall back to folder contents or existing selections only when manufacturer list is missing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cc4d7ed808328af675cdadb23d544)