### PR TITLE
Add fixed catalog links to lineup table

### DIFF
--- a/VendingLineup
+++ b/VendingLineup
@@ -435,10 +435,17 @@
       const FALLBACK_IMAGE =
         'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="360" height="240" viewBox="0 0 360 240"><rect width="360" height="240" fill="%23f2f4f7"/><rect x="30" y="30" width="300" height="180" rx="12" fill="none" stroke="%23c3cad4" stroke-width="8"/><path d="M96 166l48-58 48 58 48-72 24 32" fill="none" stroke="%23c3cad4" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/><circle cx="138" cy="90" r="22" fill="%23d8dde5"/></svg>';
 
-      const MAX_TABLE_COLUMNS = 5;
-      const MAX_MANUFACTURERS = MAX_TABLE_COLUMNS - 1;
+        const MAX_TABLE_COLUMNS = 5;
+        const MAX_MANUFACTURERS = MAX_TABLE_COLUMNS - 1;
 
-      const PREFERRED_MANUFACTURER_ORDER = ['ポッカサッポロ', 'アサヒ', 'キリン', '伊藤園'];
+        const PREFERRED_MANUFACTURER_ORDER = ['ポッカサッポロ', 'アサヒ', 'キリン', '伊藤園'];
+
+        const MANUFACTURER_CATALOG_LINKS = [
+          'https://docs.google.com/presentation/d/1VcC37X82H9wtj3zW_pEVM5B8OWP8ycxXheVJnYal2kQ/edit?usp=sharing',
+          'https://drive.google.com/file/d/1omU2GbhqJlPQ_6RslD-DPa0NO_aJplsK/view?usp=sharing',
+          'https://drive.google.com/file/d/1Y0hQLd3C-9q75exTyQYwQDjMVHNYm-UK/view?usp=sharing',
+          'https://drive.google.com/file/d/1pzSG-GG5S_y7Lq_wXhgaFPwbkQ_Ove2C/view?usp=sharing',
+        ];
 
       const params = new URLSearchParams(window.location.search);
       const maker = params.get('maker') || makerFromTemplate || '';
@@ -694,7 +701,7 @@
 
         const orderedManufacturers = enforcePreferredOrder(paddedManufacturers);
 
-        const manufacturerEntries = orderedManufacturers.map((makerEntry) => {
+        const manufacturerEntries = orderedManufacturers.map((makerEntry, index) => {
           const name = getMakerDisplayName(makerEntry);
           const isKirin = /キリン/.test(name);
           const isAsahi = /アサヒ/.test(name);
@@ -702,7 +709,7 @@
           return {
             name,
             imageUrl: makerEntry.imageUrl || '',
-            catalogUrl: makerEntry.catalogUrl || '',
+            catalogUrl: MANUFACTURER_CATALOG_LINKS[index] || makerEntry.catalogUrl || '',
             customStatus: {
               text: isKirin ? '可能' : '不可(販売会社決定)',
               className: isKirin ? 'status-allow' : 'status-deny',
@@ -763,7 +770,7 @@
             label: 'カタログ',
             accessor: (entry) =>
               entry.catalogUrl
-                ? { href: entry.catalogUrl, text: 'カタログを見る' }
+                ? { href: entry.catalogUrl, text: 'カタログ' }
                 : '',
           },
           { label: '商品カスタマイズ', accessor: (entry) => entry.customStatus },


### PR DESCRIPTION
## Summary
- add fixed catalog links for each manufacturer column in the lineup table
- render catalog cells with the catalog label linked to the provided URLs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cc5d08e1083289936b2e7f35dd9ea)