### PR TITLE
Remove manufacturer row and ensure catalog links open in new tab

### DIFF
--- a/VendingLineup
+++ b/VendingLineup
@@ -727,7 +727,6 @@
 
         const tbody = document.createElement('tbody');
         const rows = [
-          { label: 'メーカー名', accessor: (entry) => entry.name },
           { label: '商品カスタマイズ', accessor: (entry) => entry.customStatus },
           { label: 'カタログ', accessor: (entry) => entry.catalogLink, cellClass: 'lineup-text' },
           { label: '備考', accessor: (entry) => entry.note },
@@ -743,7 +742,23 @@
           manufacturerEntries.forEach((entry) => {
             const td = document.createElement('td');
             const value = row.accessor(entry);
-            if (value && typeof value === 'object') {
+            if (row.label === 'カタログ') {
+              const href =
+                (value && typeof value === 'object' && value.href) ||
+                (typeof value === 'string' && /^https?:\/\//.test(value) ? value : '');
+              const linkText = (value && typeof value === 'object' && value.text) || 'カタログを見る';
+
+              if (href) {
+                const link = document.createElement('a');
+                link.href = href;
+                link.textContent = linkText;
+                link.target = '_blank';
+                link.rel = 'noopener noreferrer';
+                td.appendChild(link);
+              } else {
+                td.textContent = (value && typeof value === 'object' ? value.text : value) || '';
+              }
+            } else if (value && typeof value === 'object') {
               if (value.href) {
                 const link = document.createElement('a');
                 link.href = value.href;


### PR DESCRIPTION
## Summary
- remove the manufacturer name row from the lineup table
- render catalog entries as links that open in a new tab when a URL is available
- preserve fallback catalog text when no link is present

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cd0a525508328ba24a85de6fe8a45)