### PR TITLE
Handle rendering errors when adding catalog links

### DIFF
--- a/VendingLineup
+++ b/VendingLineup
@@ -605,16 +605,17 @@
       });
 
       function renderLineup(data) {
-        const container = document.getElementById('lineupContainer');
-        const manufacturer = (data && data.manufacturer) || maker || '';
-        const categories = (data && data.categories) || [];
-        const manufacturers = (data && data.manufacturers) || [];
-        const extraCatalogLinks = [
-          { href: 'https://drive.google.com/file/d/1uMHmR0DJm7OMKq9Qqh-eOs_5ezP2HHY_/view?usp=sharing', text: 'カタログ1' },
-          { href: 'https://drive.google.com/file/d/1omU2GbhqJlPQ_6RslD-DPa0NO_aJplsK/view?usp=sharing', text: 'カタログ2' },
-          { href: 'https://drive.google.com/file/d/1Y0hQLd3C-9q75exTyQYwQDjMVHNYm-UK/view?usp=sharing', text: 'カタログ3' },
-          { href: 'https://drive.google.com/file/d/1pzSG-GG5S_y7Lq_wXhgaFPwbkQ_Ove2C/view?usp=sharing', text: 'カタログ4' },
-        ];
+        try {
+          const container = document.getElementById('lineupContainer');
+          const manufacturer = (data && data.manufacturer) || maker || '';
+          const categories = (data && data.categories) || [];
+          const manufacturers = (data && data.manufacturers) || [];
+          const extraCatalogLinks = [
+            { href: 'https://drive.google.com/file/d/1uMHmR0DJm7OMKq9Qqh-eOs_5ezP2HHY_/view?usp=sharing', text: 'カタログ1' },
+            { href: 'https://drive.google.com/file/d/1omU2GbhqJlPQ_6RslD-DPa0NO_aJplsK/view?usp=sharing', text: 'カタログ2' },
+            { href: 'https://drive.google.com/file/d/1Y0hQLd3C-9q75exTyQYwQDjMVHNYm-UK/view?usp=sharing', text: 'カタログ3' },
+            { href: 'https://drive.google.com/file/d/1pzSG-GG5S_y7Lq_wXhgaFPwbkQ_Ove2C/view?usp=sharing', text: 'カタログ4' },
+          ];
 
         const allItems = categories.flatMap((category) => {
           if (!category.items || !category.items.length) return [];
@@ -759,6 +760,14 @@
               }
               tr.appendChild(td);
             });
+          } else if (extraCatalogLinks.length) {
+            extraCatalogLinks.forEach(() => {
+              const td = document.createElement('td');
+              if (row.cellClass) {
+                td.classList.add(row.cellClass);
+              }
+              tr.appendChild(td);
+            });
           }
 
           manufacturerEntries.forEach((entry) => {
@@ -813,7 +822,11 @@
         section.appendChild(tableWrapper);
 
         container.appendChild(section);
+      } catch (err) {
+        console.error(err);
+        showError(err);
       }
+    }
 
       function showError(err) {
         const container = document.getElementById('lineupContainer');


### PR DESCRIPTION
## Summary
- wrap lineup rendering in a try/catch to surface errors instead of leaving the page blank
- add placeholder catalog cells for non-catalog rows to keep the table layout consistent

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cd895cadc8328b21b0e19122db1ae)