### PR TITLE
Adjust catalog display alignment

### DIFF
--- a/VendingLineup
+++ b/VendingLineup
@@ -382,7 +382,7 @@
       }
 
       .lineup-text {
-        text-align: left;
+        text-align: right;
         color: #2f3345;
         line-height: 1.5;
         font-size: 13px;
@@ -735,7 +735,7 @@
           note: isAsahi ? '※設置できない可能性あり' : '',
           catalogLink: catalogUrl
             ? { href: catalogUrl, text: 'カタログを見る' }
-            : '準備中',
+            : '',
         };
       });
 


### PR DESCRIPTION
## Summary
- align catalog row text to the right so catalog links appear right-justified
- remove the "準備中" placeholder when no catalog link is available

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cde4297f88328babf312235dbec27)