### PR TITLE
Remove email retrieval from survey responses

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -355,28 +355,5 @@ function submitSurveyResponse(question1Answer, question2Answer) {
     throw new Error('集計シートが見つかりません。');
   }
 
-  var email = getUserEmail();
-
-  sheet.appendRow([new Date(), email || '', question1Answer || '', question2Answer || '']);
-}
-
-/**
- * 現在ログインしているユーザーのメールアドレスを内部的に取得する。
- * Apps Script の実行権限に応じて ActiveUser または EffectiveUser を参照する。
- * @returns {string}
- */
-function getUserEmail() {
-  var active = Session.getActiveUser();
-  if (active) {
-    var email = active.getEmail();
-    if (email) return email;
-  }
-
-  var effective = Session.getEffectiveUser();
-  if (effective) {
-    var effectiveEmail = effective.getEmail();
-    if (effectiveEmail) return effectiveEmail;
-  }
-
-  return '';
+  sheet.appendRow([new Date(), question1Answer || '', question2Answer || '']);
 }


### PR DESCRIPTION
## Summary
- stop capturing user email when recording survey responses
- remove the unused helper that attempted to read the active user's email

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ce1211d308328884d884aa8fed879)