### PR TITLE
Highlight maker names in lineup

### DIFF
--- a/VendingLineup
+++ b/VendingLineup
@@ -263,9 +263,10 @@
       }
 
       .image-grid figcaption {
-        font-size: 13px;
+        font-size: 15px;
+        font-weight: 700;
         margin-top: 6px;
-        color: #3a3f52;
+        color: var(--accent-2);
         text-align: center;
       }
 


### PR DESCRIPTION
## Summary
- Increase the maker name captions in the lineup grid for greater emphasis
- Use the accent blue color and bold weight to make manufacturer names stand out

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ce1ccc2788328b07d93ebf2d71979)