### PR TITLE
Adjust manufacturer caption typography

### DIFF
--- a/VendingLineup
+++ b/VendingLineup
@@ -263,10 +263,10 @@
       }
 
       .image-grid figcaption {
-        font-size: 15px;
-        font-weight: 700;
+        font-size: 17px;
+        font-weight: 800;
         margin-top: 6px;
-        color: var(--accent-2);
+        color: #2f3345;
         text-align: center;
       }
 


### PR DESCRIPTION
## Summary
- increase manufacturer caption text size and weight to make it more prominent
- darken manufacturer caption color to reduce brightness

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ce28b4c348328beda8121474062f3)