### PR TITLE
Add thank you page and log survey responses to 回答 sheet

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -28,7 +28,7 @@ function normalizeKey(value) {
 var SURVEY_SPREADSHEET_ID = '1xkg8vNscpcWTA6GA0VPxGTJCAH6LyvsYhq7VhOlDcXg';
 
 /** 集計結果を書き込むシート名 */
-var SURVEY_SHEET_NAME = '集計';
+var SURVEY_SHEET_NAME = '回答';
 
 /**
  * Vending lineup web app entry point.
@@ -49,6 +49,42 @@ function doGet(e) {
     .setTitle('商品ラインアップ')
     .addMetaTag('viewport', 'width=device-width, initial-scale=1')
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
+}
+
+/**
+ * フォーム送信後にサンクスページを表示する。
+ * @param {GoogleAppsScript.Events.DoPost} e
+ * @returns {GoogleAppsScript.HTML.HtmlOutput}
+ */
+function doPost(e) {
+  var params = (e && e.parameter) || {};
+  var question1 = params.question1Answer || params.question1 || params.q1 || '';
+  var question2 = params.question2Answer || params.question2 || params.q2 || '';
+
+  try {
+    submitSurveyResponse(question1, question2);
+    return HtmlService.createHtmlOutput(
+      '<!DOCTYPE html>' +
+        '<html lang="ja">' +
+        '<head>' +
+        '<meta charset="UTF-8" />' +
+        '<meta name="viewport" content="width=device-width, initial-scale=1" />' +
+        '<title>送信完了</title>' +
+        '<style>body{font-family:\"Noto Sans JP\",sans-serif;padding:32px;text-align:center;}h1{font-size:22px;margin-bottom:12px;}p{margin:0;color:#444;}</style>' +
+        '</head>' +
+        '<body>' +
+        '<h1>送信しました！</h1>' +
+        '<p>ご回答ありがとうございました。</p>' +
+        '</body>' +
+        '</html>'
+    );
+  } catch (err) {
+    return HtmlService.createHtmlOutput(
+      '<p>送信に失敗しました: ' +
+        (err && err.message ? err.message : '不明なエラー') +
+        '</p>'
+    ).setTitle('送信エラー');
+  }
 }
 
 /**

--- a/VendingLineup
+++ b/VendingLineup
@@ -28,7 +28,7 @@ function normalizeKey(value) {
 var SURVEY_SPREADSHEET_ID = '1xkg8vNscpcWTA6GA0VPxGTJCAH6LyvsYhq7VhOlDcXg';
 
 /** 集計結果を書き込むシート名 */
-var SURVEY_SHEET_NAME = '集計';
+var SURVEY_SHEET_NAME = '回答';
 
 /**
  * Vending lineup web app entry point.
@@ -49,6 +49,42 @@ function doGet(e) {
     .setTitle('自販機アンケート')
     .addMetaTag('viewport', 'width=device-width, initial-scale=1')
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
+}
+
+/**
+ * フォーム送信後にサンクスページを表示する。
+ * @param {GoogleAppsScript.Events.DoPost} e
+ * @returns {GoogleAppsScript.HTML.HtmlOutput}
+ */
+function doPost(e) {
+  var params = (e && e.parameter) || {};
+  var question1 = params.question1Answer || params.question1 || params.q1 || '';
+  var question2 = params.question2Answer || params.question2 || params.q2 || '';
+
+  try {
+    submitSurveyResponse(question1, question2);
+    return HtmlService.createHtmlOutput(
+      '<!DOCTYPE html>' +
+        '<html lang="ja">' +
+        '<head>' +
+        '<meta charset="UTF-8" />' +
+        '<meta name="viewport" content="width=device-width, initial-scale=1" />' +
+        '<title>送信完了</title>' +
+        '<style>body{font-family:\"Noto Sans JP\",sans-serif;padding:32px;text-align:center;}h1{font-size:22px;margin-bottom:12px;}p{margin:0;color:#444;}</style>' +
+        '</head>' +
+        '<body>' +
+        '<h1>送信しました！</h1>' +
+        '<p>ご回答ありがとうございました。</p>' +
+        '</body>' +
+        '</html>'
+    );
+  } catch (err) {
+    return HtmlService.createHtmlOutput(
+      '<p>送信に失敗しました: ' +
+        (err && err.message ? err.message : '不明なエラー') +
+        '</p>'
+    ).setTitle('送信エラー');
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- append survey submissions to the 回答 sheet in the provided spreadsheet
- add a doPost handler that records responses and returns a thank-you page after submission

## Testing
- not run (Apps Script environment not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cedf7d0508328bc00d963074acabc)